### PR TITLE
Add about page

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: "About the hpc.social Community Blog"
+permalink: /about/
+---
+
+This belongs in the hpc.social family of blogs. In particular, this is an aggregated feed of personal posts that meet the following criteria:
+
+> The [personal blogs feed](https://hpc.social/personal-blog/) is the "soul" of the HPC community - HPCers who are personally invested in the details of the work they are doing, the projects they are working on with some content about their culture and pet pictures :D - things that we all find in common and share and talk about.
+
+>  The [community blogs feed](https://hpc.social/community-blog/) gathers content from blogs for projects, ecosystems, or governance boards that talk about specific community interested content around the work they represent. The content range from release notes, tricks and tips, discussion around tooling and infrastructure, and other things that are neutrally branded. Discussion of branded topics like CUDA, SYCL, and oneAPI are ok - discussions about hardware are ok. Product announcements are not ok especially.
+
+The hpc.social blogs aim to gather feeds that share ideas, news, and stories from diverse people, centers and groups across the 
+High Performance Computing (HPC) community.
+Whether you are an advanced practitioner, a developer whose work touches or intersects HPC, or a true novice just starting out, your voice is welcome here. 
+These community and personal blog feeds as linked above provide a syndicated set of our community voices. 
+You can subscribe to via a variety of channels (below) and also follow instructions in each page to contribute your own feed.
+
+ - [Add your blog in the personal feed](https://github.com/hpc-social/personal-blog)
+ - [Add your blog in the community feed](https://github.com/hpc-social/community-blog)
+
+As a word of caution, we review and curate authors at the point of adding the blog, but do not regularly monitor individual posts that are added. 
+The opinions expressed in these blogs are owned by the authors and do not reflect the opinion of the hpc.social community at large. 
+Offensive or inappropriate posts should be reported to [info@hpc.social](mailto:info@hpc.social) if you wish to report anonymously. 
+You can also submit a pull request to remove the offending feed if you are comfortable doing so publicly.


### PR DESCRIPTION
The "about" page seemed to go missing in the recent refactoring. This file attempts to add it.